### PR TITLE
move original annotation source from MGI to GO_Central

### DIFF
--- a/src/gopreprocess/ortho_annotation_creation_controller.py
+++ b/src/gopreprocess/ortho_annotation_creation_controller.py
@@ -330,7 +330,7 @@ class AnnotationCreationController:
                     new_annotation.object.taxon = Curie.from_str(self.target_taxon)
                     new_annotation.object_extensions = []
                     new_annotation.subject_extensions = []
-                    new_annotation.provided_by = taxon_to_provider[self.target_taxon]
+                    new_annotation.provided_by = "GO_Central"
                     new_annotation.subject.fullname = target_genes[taxon_to_provider[self.target_taxon] + ":" + gene][
                         "fullname"
                     ]


### PR DESCRIPTION
Per https://github.com/geneontology/go-site/issues/2043, all ortho annotations should be assigned_by "GO_Central"