### PR TITLE
[bot] Unbreak CI and make the lint QC env actually check

### DIFF
--- a/.github/workflows/pr-test-qc.yml
+++ b/.github/workflows/pr-test-qc.yml
@@ -21,15 +21,15 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      - uses: actions/checkout@v3.0.2
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
         name: setup python environment
         with:
           python-version: ${{ matrix.python }}
 
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.1
+        uses: snok/install-poetry@v1.4.2
       - name: Install dependencies
         run: poetry install --no-interaction
 

--- a/.github/workflows/pr-test-qc.yml
+++ b/.github/workflows/pr-test-qc.yml
@@ -16,6 +16,8 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
+      # Report every version rather than cancelling the rest on the first failure.
+      fail-fast: false
       matrix:
         python: [ "3.9", "3.10", "3.11", "3.12" ]
 
@@ -30,6 +32,13 @@ jobs:
 
       - name: Install Poetry
         uses: snok/install-poetry@v1.4.2
+        with:
+          # Poetry >=2.2 requires Python >=3.10, and pyproject declares
+          # python = ">=3.9". 2.1.3 is the last release supporting 3.9, so this
+          # keeps the whole declared support range testable. Dropping 3.9 and
+          # raising the floor to >=3.10 would let this pin go, but that is a
+          # support-policy decision rather than a CI fix.
+          version: "2.1.3"
       - name: Install dependencies
         run: poetry install --no-interaction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ line-length = 170
 target-version = ["py39", "py310"]
 
 [tool.ruff]
+line-length = 170
+
+[tool.ruff.lint]
 extend-ignore = [
     "D211", # `no-blank-line-before-class`
     "D212", # `multi-line-summary-first-line`
@@ -57,7 +60,6 @@ extend-ignore = [
     "B008", # `Do not perform function calls in argument defaults.`
     "F841", # `local variable 'x' is assigned to but never used`
 ]
-line-length = 170
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]

--- a/tests/test_gaf_processor.py
+++ b/tests/test_gaf_processor.py
@@ -23,7 +23,6 @@ RGD\t10045371\tMir155hg\tlocated_in\tGO:0005737\tRGD:1624291\tISO\tUniProtKB:C0H
 def gaf_processor():
     """Fixture for creating a GafProcessor instance with mocked dependencies."""
     with patch("src.gopreprocess.file_processors.gaf_processor.GafParser") as MockGafParser, patch("src.gopreprocess.file_processors.gaf_processor.EcoMap") as MockEcoMap:
-
         # Creating an instance of GafProcessor for testing
         processor = GafProcessor(
             filepath=Path("dummy/path"),

--- a/tox.ini
+++ b/tox.ini
@@ -34,20 +34,26 @@ commands = coverage erase
 # This is used during development
 [testenv:lint-fix]
 deps =
-    black
-    ruff
+    # Pinned deliberately, and matching the black = "^23.7.0" constraint in
+    # pyproject. Unpinned, this env installed whatever black was newest, so CI's
+    # formatting opinion changed without any code change -- black >=26 also strips
+    # the blank line before class docstrings, which this project keeps (see the
+    # D211 entry in the ruff ignore list).
+    black~=23.12
+    ruff==0.16.0
 commands =
     black src/ tests/
     ruff check --fix src/ tests/
-description = Run linters.
+description = Run linters and apply fixes (developer-facing).
 
 # This is used for QC checks. Unlike lint-fix, this must not rewrite files:
 # in CI the rewrites would land in a throwaway runner and the step would pass
 # regardless of whether the code was actually formatted correctly.
 [testenv:lint]
 deps =
-    black
-    ruff
+    # Keep in step with lint-fix above.
+    black~=23.12
+    ruff==0.16.0
 commands =
     black --check --diff src/ tests/
     ruff check src/ tests/

--- a/tox.ini
+++ b/tox.ini
@@ -41,15 +41,17 @@ commands =
     ruff check --fix src/ tests/
 description = Run linters.
 
-# This is used for QC checks.
+# This is used for QC checks. Unlike lint-fix, this must not rewrite files:
+# in CI the rewrites would land in a throwaway runner and the step would pass
+# regardless of whether the code was actually formatted correctly.
 [testenv:lint]
 deps =
     black
     ruff
 commands =
-    black  src/ tests/
-    ruff check --fix src/ tests/
-description = Run linters.
+    black --check --diff src/ tests/
+    ruff check src/ tests/
+description = Check formatting and lint without modifying files.
 
 [testenv:doclint]
 deps =


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Fixes #80.

**CI is now green on 3.9, 3.10, 3.11 and 3.12.** It took four distinct problems, each hidden behind the previous one.

## 1. Exit 127 at `Install dependencies`

Poetry installed successfully to `/home/runner/.local/bin` and the action reported `outcome=success`, then the next step could not find `poetry`. `snok/install-poetry@v1.3.1` exports PATH via the `save-state` / `set-output` workflow commands, which GitHub has since disabled — the logs carry the deprecation warnings. `actions/checkout@v3.0.2` and `actions/setup-python@v2` were the same vintage.

Bumped to `actions/checkout@v5`, `actions/setup-python@v6`, `snok/install-poetry@v1.4.2`.

## 2. Python 3.9 could not install Poetry at all

With the PATH problem gone, 3.9 failed inside Poetry's own installer: **Poetry 2.4.1 requires Python >= 3.10**. Since `pyproject.toml` declares `python = ">=3.9"`, Poetry is pinned to **2.1.3** — the last release supporting 3.9 — rather than silently narrowing the range the project claims to support. Dropping 3.9 and raising the floor to `>=3.10` would let that pin go, but that is a support-policy decision, not a CI fix.

Also set `fail-fast: false`: 3.9's failure was cancelling 3.10/3.11/3.12 and hiding whether they were healthy.

## 3. `tox -e lint` never checked anything

The workflow's QC step runs `poetry run tox -e lint`, and that env was byte-identical to `lint-fix`:

```ini
commands =
    black  src/ tests/
    ruff check --fix src/ tests/
```

Both **rewrite files and exit 0**. In CI the rewrites land in a throwaway runner and are discarded, so the step passed regardless of whether the code was formatted correctly. Now `black --check --diff` and `ruff check` with no `--fix`; `lint-fix` stays as the mutating developer env.

That found one genuine problem it had been masking: `tests/test_gaf_processor.py` had a stray blank line after a `with`. One line removed.

## 4. The lint envs installed unpinned tools

Making the check strict immediately failed — but on 7 files, not one. `tox.ini` installed `black` and `ruff` unpinned into an isolated env, so CI resolved **black 26.5.1** while `pyproject.toml` declares `black = "^23.7.0"` as a project dependency. CI was enforcing a different tool than the project specifies, and its opinion would change with every black release independent of any code change.

Concretely: **black >= 26 strips the blank line before class docstrings**, which this project keeps deliberately — `D211` (`no-blank-line-before-class`) is in the ruff ignore list. Under black 26 that is a 7-file repo-wide restyle; under the black the project declares, the tree is clean.

Both lint envs now pin `black~=23.12` and `ruff==0.16.0`. Adopting black 26's style would be a separate, deliberate decision, not something to smuggle into a CI fix.

## 5. Deprecated ruff config keys

`extend-ignore`, `fixable` and `select` moved under `[tool.ruff.lint]`; deprecated at the top level and warned on every run. `line-length` stays top-level, where it belongs.

## Correction to #80

Issue #80 as I originally filed it claimed `pyproject.toml` has no `[tool.black]` section and that black therefore fell back to line-length 88, disagreeing with ruff's 170. **That was wrong** — `[tool.black]` exists with `line-length = 170`, so the two already agreed. The real cause was the unpinned tools in item 4. I have corrected the issue body and the corresponding note in #79.

## Verification

From the green run's own log, showing the checks are real rather than vacuous:

```
lint: install_deps> python -I -m pip install 'black~=23.12' ruff==0.16.0
lint: black==23.12.1,...,ruff==0.16.0
lint: commands[0]> black --check --diff src/ tests/
23 files would be left unchanged.
lint: commands[1]> ruff check src/ tests/
All checks passed!
codespell: commands[0]> codespell src/ tests/
  congratulations :)
py: commands[0]> poetry run pytest
============= 7 passed, 1 skipped, 10 warnings in 64.28s =============
```

## Scope

Only CI and tooling configuration, plus one blank line in a test fixture. No `src/` behaviour changes. This is deliberately separate from #79, which changes how the Alliance orthology input is read and reaches production on the next Thursday run after it merges — mixing a CI overhaul into that would make both harder to review. Once this lands, #79 should be rebased so it gets a real CI run.

_— Posted by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
