### PR TITLE
[bot] Docs: pandas applymap landmine and a production-validation recipe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,13 @@ GOA linkage was provable at all.
   `p2go-homology-upstream-file-generator`, which is what actually runs.
 - The uncompressed `.gaf` on the mirror is **stale since 2024-04-09**; only the
   `.gz` is covered by the publishing s3cmd glob.
+- **`ortho_annotation_creation_controller.py:51` uses `DataFrame.applymap`,
+  removed in pandas 2.1+.** `poetry.lock` pins pandas 2.2.1, where it still
+  exists but is deprecated, so production is fine — this breaks the moment
+  pandas is bumped. The replacement is `DataFrame.map`.
+- Running outside poetry needs the lockfile's numeric stack, not just latest:
+  `numpy==1.26.4`, `scipy==1.12.0`, `pandas==2.2.1`. Installing current versions
+  gets you pandas 3.x and the `applymap` failure above.
 
 ## Working here
 
@@ -126,3 +133,31 @@ Because `main` deploys to production unreviewed on the next Thursday, treat
 merges to `main` as releases: verify against real Alliance/GOA inputs, not just
 fixtures, and prefer changes that fail loudly over changes that degrade
 quietly.
+
+### Validating a change against production output
+
+Unit tests will not tell you whether output drifted — they run on fixtures.
+Reproduce the production chain locally and diff against the live product:
+
+```bash
+export PYSTOW_HOME=/tmp/gopreprocess-run
+poetry run download -source_taxon "NCBITaxon:9606" -target_taxon "NCBITaxon:10090"
+poetry run download -source_taxon "NCBITaxon:10116" -target_taxon "NCBITaxon:10090"
+make convert_human convert_rat convert_p2g_annotations merge_gafs
+# result: $PYSTOW_HOME/GAF_OUTPUT/mgi-p2go-homology.gaf.gz
+```
+
+Compare against `https://mirror.geneontology.io/mgi-p2go-homology.gaf.gz` (the
+current live product) by `GO_REF` counts, then as sets. Two things make the
+comparison trustworthy and are worth preserving:
+
+- The human and rat inputs come from skyhook paths that the pipeline stages, so
+  a local run reads **the same bytes the last production run used** — the only
+  variables are what you changed.
+- Normalise before diffing. Annotation dates are the run date, so they always
+  differ; and MGI renames gene symbols between GPI releases, which shows up as
+  spurious "lost" annotations unless you blank columns 3 and 10 too.
+
+A healthy run is ~620k annotations, ~232k under `GO_REF:0000119` and ~75k under
+`GO_REF:0000096`. Those two are the orthology-inferred half — if they collapse,
+the Alliance input changed shape.


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Documentation only — no `src/` changes, so nothing here reaches the Thursday production run. Follows on from #78 / #79.

Two things were learned while doing #78 and captured only in a PR body, which is not somewhere a future contributor will look.

## The pandas `applymap` landmine

`src/gopreprocess/ortho_annotation_creation_controller.py:51` calls `DataFrame.applymap`, **removed in pandas 2.1+**. `poetry.lock` pins pandas 2.2.1, where it still exists but is deprecated, so production is fine — this is latent and breaks the moment pandas is bumped. The replacement is `DataFrame.map`.

I hit this running the pipeline locally against a fresh environment, which resolved pandas 3.x. Also recorded is the lockfile numeric stack needed to run outside poetry (`numpy==1.26.4`, `scipy==1.12.0`, `pandas==2.2.1`), since installing current versions gets you pandas 3.x and exactly that failure.

Not fixed here on purpose: it is a one-line change to `src/`, and `src/` changes reach production unreviewed on the next Thursday. Worth its own issue and its own run rather than riding along with a docs commit.

## How to validate a change against production output

Unit tests run on fixtures and will not tell you whether the output drifted — which matters in this repo specifically, because `main` reaches production with no review gate.

The recipe reproduces the production chain locally and diffs against the live mirror product. Two non-obvious parts are the reason it is worth writing down:

- A local run reads the **same skyhook-staged human and rat inputs the last production run used**, so the only variable is your change. That is what made the #79 comparison trustworthy.
- Diffs must normalise out **both** the run date (always differs) **and** MGI's gene-symbol renames between GPI releases. Without the latter, renamed genes read as lost annotations — in #79 that showed up as 467 apparently-lost annotations that were really 23 renames like `Car5a`→`Ca5a`.

It also records the expected healthy counts (~620k total, ~232k `GO_REF:0000119`, ~75k `GO_REF:0000096`), so a collapse in the orthology-inferred half is recognisable at a glance.

_— Posted by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
