### PR TITLE
[bot] Replace DataFrame.applymap with DataFrame.map (removed in pandas 2.1+)

### DIFF
--- a/src/gopreprocess/ortho_annotation_creation_controller.py
+++ b/src/gopreprocess/ortho_annotation_creation_controller.py
@@ -48,7 +48,7 @@ def dump_converted_annotations(converted_target_annotations: List[List[str]], so
     """
     # using pandas in order to take advantage of pystow in terms of file location and handling
     df = pd.DataFrame(converted_target_annotations)
-    df = df.applymap(convert_curie_to_string)
+    df = df.map(convert_curie_to_string)
     # Deduplicate the rows
     df_deduplicated = df.drop_duplicates()
 


### PR DESCRIPTION
[bot] Opened by a Claude Code agent on behalf of @kltm.

Fixes #83.

One line: `DataFrame.applymap` → `DataFrame.map` in `ortho_annotation_creation_controller.py`.

## Why it matters

`applymap` was **removed in pandas 2.1+**. It survives only because `poetry.lock` pins pandas 2.2.1, where it still exists but emits a `FutureWarning`. It sits on the orthology conversion path — about half this repo's output — and `main` reaches production unreviewed on the next Thursday run, so a routine dependency bump would have shipped the break rather than caught it.

Surfaced while running the pipeline locally for #78 against a fresh environment, which resolved pandas 3.x and died with `AttributeError: 'DataFrame' object has no attribute 'applymap'`.

## Verification

`DataFrame.map` was added in pandas 2.1.0 as the direct replacement, renamed only to stop colliding with `Series.map`. Rather than take the docs' word for it, I ran the real transform both ways against the **pinned pandas 2.2.1**, over rows shaped like what the controller actually builds — `Curie` objects in several columns, a duplicate row, and a negative value in column 13:

```
element-wise transform identical  : True
after dedup/coerce/group identical: True
duplicate row collapsed           : True
negative clamped to 0             : True
```

And the actual job the function does is unchanged:

```
before:    ['Curie', 'Curie', 'int64']
after map: ['str', 'str', 'int64'] -> ['MGI:104513', 'GO:0008270']
matches applymap: True
```

So this is forward-compatible *and* a no-op against the current pin — the output of the next production run should be unaffected by it.

`ruff` clean, `black` clean, 12 passed / 1 skipped.

## Timing

Today's run (2026-07-30) completed cleanly with the #79 code: 621,949 annotations, `GO_REF:0000119` 232,271, `GO_REF:0000096` 74,758 — within +0.4% of the previous run and within ~100 annotations of what my local validation predicted. The archive step also worked, so `mgi-p2go-homology-20260730.gaf.gz` now exists as a rollback point alongside the manual `20260723`.

_— Posted by Claude Code agent on behalf of @kltm._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
